### PR TITLE
Better support for dimensionless quantities

### DIFF
--- a/src/UnitfulEquivalences.jl
+++ b/src/UnitfulEquivalences.jl
@@ -27,6 +27,9 @@ macro equivalence(name)
     end
 end
 
+# A unit that is equivalent to NoUnits but doesn’t vanish when multiplied by a number
+const UnitUnit = Unitful.Hz*Unitful.s
+
 """
     edconvert(d::Dimensions, x::AbstractQuantity, e::Equivalence)
 
@@ -41,6 +44,7 @@ julia> edconvert(dimension(u"J"), 1u"kg", MassEnergy()) # E = m*c^2
 """
 edconvert(d::Dimensions, x::AbstractQuantity, e::Equivalence) =
     throw(ArgumentError("$e defines no equivalence between dimensions $(dimension(x)) and $d."))
+edconvert(d::Dimensions, x::Number, e::Equivalence) = edconvert(d, x*UnitUnit, e)
 
 """
     uconvert(u::Units, x::Quantity, e::Equivalence)
@@ -57,8 +61,7 @@ julia> uconvert(u"eV", 589u"nm", PhotonEnergy()) # photon energy of sodium D₂ 
 2.104994880020378 eV
 ```
 """
-Unitful.uconvert(u::Units, x::AbstractQuantity, e::Equivalence) =
-    uconvert(u, edconvert(dimension(u), x, e))
+Unitful.uconvert(u::Units, x, e::Equivalence) = uconvert(u, edconvert(dimension(u), x, e))
 
 """
     ustrip([T::Type,] u::Units, x::Quantity, e::Equivalence)
@@ -77,10 +80,8 @@ julia> ustrip(u"eV", 589u"nm", PhotonEnergy()) # photon energy (in eV) of sodium
 2.104994880020378
 ```
 """
-Unitful.ustrip(u::Units, x::AbstractQuantity, e::Equivalence) =
-    ustrip(u, edconvert(dimension(u), x, e))
-Unitful.ustrip(T::Type, u::Units, x::AbstractQuantity, e::Equivalence) =
-    ustrip(T, u, edconvert(dimension(u), x, e))
+Unitful.ustrip(u::Units, x, e::Equivalence)          = ustrip(u, edconvert(dimension(u), x, e))
+Unitful.ustrip(T::Type, u::Units, x, e::Equivalence) = ustrip(T, u, edconvert(dimension(u), x, e))
 
 """
     dimtype(x)

--- a/src/UnitfulEquivalences.jl
+++ b/src/UnitfulEquivalences.jl
@@ -3,7 +3,8 @@ module UnitfulEquivalences
 export @equivalence, @eqrelation, Equivalence, MassEnergy, PhotonEnergy
 
 import Unitful
-using Unitful: AbstractQuantity, Dimensions, Level, Quantity, Units, dimension, uconvert
+using Unitful: AbstractQuantity, DimensionlessQuantity, Dimensions, Level, NoDims, Quantity,
+               Units, dimension, uconvert
 
 """
     Equivalence
@@ -95,6 +96,7 @@ Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}
 ```
 """
 dimtype(::Type{Union{Quantity{T,D,U}, Level{L,S,Quantity{T,D,U}} where {L,S}} where {T,U}}) where D = typeof(D)
+dimtype(::typeof(DimensionlessQuantity)) = typeof(NoDims)
 
 """
     @eqrelation Name a/b = c

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,28 +29,31 @@ UnitfulEquivalences.edconvert(::typeof(dimension(u"s")), x::Unitful.Length, ::No
     @test uconvert(u"kg", 10u"K", Equiv1()) === 0.02u"kg"
     @test uconvert(u"K", 10u"kg", Equiv1()) === 5000.0u"K"
     @test uconvert(u"eV", 10u"mm/m", Equiv1()) === (1//100)u"eV"
+    @test uconvert(u"eV", 10, Equiv1()) === 10u"eV"
     @test uconvert(NoUnits, 10u"eV", Equiv1()) === 10
     @test ustrip(u"ms", 1u"inch", Equiv1()) === (254//100)
     @test ustrip(u"km", 1.0u"d", Equiv1()) === 864.0
     @test ustrip(u"kg", 10u"K", Equiv1()) === 0.02
     @test ustrip(u"K", 10u"kg", Equiv1()) === 5000.0
     @test ustrip(u"eV", 10u"mm/m", Equiv1()) === 1//100
+    @test ustrip(u"eV", 10, Equiv1()) === 10
     @test ustrip(NoUnits, 10u"eV", Equiv1()) === 10
     @test ustrip(Float64, u"ms", 1u"inch", Equiv1()) === 2.54
     @test ustrip(Rational{Int}, u"km", 1.0u"d", Equiv1()) === 864//1
     @test ustrip(Float32, u"kg", 10u"K", Equiv1()) === 0.02f0
     @test ustrip(Int, u"K", 10u"kg", Equiv1()) === 5000
+    @test ustrip(Float64, u"eV", 10, Equiv1()) === 10.0
     @test_throws ArgumentError uconvert(u"s", 10u"s", Equiv1())
     @test_throws ArgumentError uconvert(u"kg", 1u"s", Equiv1())
-    @test_throws ArgumentError uconvert(u"m", 1u"kg", Equiv1())
+    @test_throws ArgumentError uconvert(u"m", 1, Equiv1())
     @test_throws MethodError   uconvert(u"km", 1u"s", Equiv1) # need instance, not type
     @test_throws ArgumentError ustrip(u"s", 10u"s", Equiv1())
     @test_throws ArgumentError ustrip(u"kg", 1u"s", Equiv1())
-    @test_throws ArgumentError ustrip(u"m", 1u"kg", Equiv1())
+    @test_throws ArgumentError ustrip(u"m", 1, Equiv1())
     @test_throws MethodError   ustrip(u"km", 1u"s", Equiv1) # need instance, not type
     @test_throws ArgumentError ustrip(Float64, u"s", 10u"s", Equiv1())
     @test_throws ArgumentError ustrip(Float64, u"kg", 1u"s", Equiv1())
-    @test_throws ArgumentError ustrip(Float64, u"m", 1u"kg", Equiv1())
+    @test_throws ArgumentError ustrip(Float64, u"m", 1, Equiv1())
     @test_throws MethodError   ustrip(Float64, u"km", 1u"s", Equiv1) # need instance, not type
 
     # Equiv2
@@ -92,6 +95,7 @@ struct Equiv4 <: Equivalence end
     @test uconvert(u"m^3", 5u"N", Equiv4()) === -0.2u"m^3"
     @test uconvert(NoUnits, 5u"eV", Equiv4()) === 5
     @test uconvert(u"keV", 5u"km/m", Equiv4()) === 5u"keV"
+    @test uconvert(u"MeV", 5, Equiv4()) === (1//200_000)u"MeV"
     @test_throws ArgumentError uconvert(u"m^3", 1u"V", Equiv4())
     @test_throws LoadError @macroexpand @eqrelation Equiv4 Unitful.Energy = Unitful.Mass * Unitful.c0^2
     @test_throws LoadError @macroexpand @eqrelation Equiv4 Unitful.Energy + Unitful.Mass = Unitful.c0^2


### PR DESCRIPTION
This allows the use of `DimensionlessQuantity` in `@eqrelation` (instead of something like `Unitful.Energy`).

Edit: `edconvert` now accepts plain numbers in place of dimensionless quantities. Fixes #6.