### PR TITLE
Remove @equivalence macro

### DIFF
--- a/src/UnitfulEquivalences.jl
+++ b/src/UnitfulEquivalences.jl
@@ -1,6 +1,6 @@
 module UnitfulEquivalences
 
-export @equivalence, @eqrelation, Equivalence, MassEnergy, PhotonEnergy
+export @eqrelation, Equivalence, MassEnergy, PhotonEnergy
 
 import Unitful
 using Unitful: AbstractQuantity, DimensionlessQuantity, Dimensions, Level, NoDims, NoUnits,
@@ -15,17 +15,6 @@ and [`PhotonEnergy`](@ref) are defined.
 abstract type Equivalence end
 
 Base.broadcastable(x::Equivalence) = Ref(x)
-
-"""
-    @equivalence Name
-
-Shorthand for `struct Name <: Equivalence end` to simplify the definition of equivalences.
-"""
-macro equivalence(name)
-    quote
-        Base.@__doc__ struct $(esc(name)) <: Equivalence end
-    end
-end
 
 """
     edconvert(d::Dimensions, x::AbstractQuantity, e::Equivalence)

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -15,7 +15,7 @@ julia> uconvert(u"keV", 1u"me", MassEnergy()) # electron rest mass is equivalent
 510.9989499961642 keV
 ```
 """
-@equivalence MassEnergy
+struct MassEnergy <: Equivalence end
 
 const c² = Quantity(convert(Int64, ustrip(c0)), unit(c0))^2
 


### PR DESCRIPTION
I don’t like the `@equivalence` macro. I think it doesn’t make things easier, it just obfuscates what is happening. (With `struct Name <: Equivalence end`, you know exactly what you get. But `@equivalence Name` could do anything.)