### PR TITLE
Rename PhotonEnergy → Spectral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `PhotonEnergy` is renamed to `Spectral`.
 * ![Feature](https://img.shields.io/badge/-feature-green) The `Thermal()` equivalence is added. ([#13](https://github.com/sostock/UnitfulEquivalences.jl/pull/13))
 
 ## v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-* ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `PhotonEnergy` is renamed to `Spectral`.
+* ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `PhotonEnergy` is renamed to `Spectral`. ([#14](https://github.com/sostock/UnitfulEquivalences.jl/pull/14))
 * ![Feature](https://img.shields.io/badge/-feature-green) The `Thermal()` equivalence is added. ([#13](https://github.com/sostock/UnitfulEquivalences.jl/pull/13))
 
 ## v0.1.1

--- a/docs/src/newequivalences.md
+++ b/docs/src/newequivalences.md
@@ -42,7 +42,7 @@ DocTestSetup = :(using Unitful, UnitfulEquivalences)
 ```
 
 An equivalence can have an arbitrary number of `edconvert` methods defined for it.
-For example, the `PhotonEnergy` equivalence can convert between energy, frequency, wavelength, and wavenumber.
+For example, the `Spectral` equivalence can convert between energy, frequency, wavelength, and wavenumber.
 For each pair of these quantities, there is one pair of `edconvert` methods defined that handles the conversion between them.
 
 ### Convenience functions

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -8,10 +8,10 @@ uconvert(u"keV", 1u"me", MassEnergy()) # electron rest mass is equivalent to ≈
 ustrip(u"keV", 1u"me", MassEnergy())
 ```
 
-The equivalences [`MassEnergy`](@ref), [`PhotonEnergy`](@ref), and [`Thermal`](@ref) are defined and exported by this package:
+The equivalences [`MassEnergy`](@ref), [`Spectral`](@ref), and [`Thermal`](@ref) are defined and exported by this package:
 ```@docs
 MassEnergy
-PhotonEnergy
+Spectral
 Thermal
 ```
 

--- a/src/UnitfulEquivalences.jl
+++ b/src/UnitfulEquivalences.jl
@@ -1,6 +1,6 @@
 module UnitfulEquivalences
 
-export @eqrelation, Equivalence, MassEnergy, PhotonEnergy, Thermal
+export @eqrelation, Equivalence, MassEnergy, Spectral, Thermal
 
 import Unitful
 using Unitful: AbstractQuantity, AffineQuantity, DimensionlessQuantity, Dimensions, Level,
@@ -9,8 +9,7 @@ using Unitful: AbstractQuantity, AffineQuantity, DimensionlessQuantity, Dimensio
 """
     Equivalence
 
-Abstract supertype for all equivalences. By default, the equivalences [`MassEnergy`](@ref)
-and [`PhotonEnergy`](@ref) are defined.
+Abstract supertype for all equivalences.
 """
 abstract type Equivalence end
 
@@ -48,7 +47,7 @@ Convert `x` to the units `u` (of different dimensions) by using the specified eq
 julia> uconvert(u"keV", 1u"me", MassEnergy()) # electron rest mass is equivalent to ≈511 keV
 510.9989499961642 keV
 
-julia> uconvert(u"eV", 589u"nm", PhotonEnergy()) # photon energy of sodium D₂ line (≈589 nm)
+julia> uconvert(u"eV", 589u"nm", Spectral()) # photon energy of sodium D₂ line (≈589 nm)
 2.104994880020378 eV
 ```
 """
@@ -68,7 +67,7 @@ resulting number to type `T`.
 julia> ustrip(u"keV", 1u"me", MassEnergy()) # electron rest mass is equivalent to ≈511 keV
 510.9989499961642
 
-julia> ustrip(u"eV", 589u"nm", PhotonEnergy()) # photon energy (in eV) of sodium D₂ line
+julia> ustrip(u"eV", 589u"nm", Spectral()) # photon energy (in eV) of sodium D₂ line
 2.104994880020378
 ```
 """

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -22,7 +22,7 @@ const c² = Quantity(convert(Int64, ustrip(c0)), unit(c0))^2
 @eqrelation MassEnergy Energy/Mass = c²
 
 """
-    PhotonEnergy(; frequency=:linear, wavelength=:linear, wavenumber=:linear)
+    Spectral(; frequency=:linear, wavelength=:linear, wavenumber=:linear)
 
 Equivalence that relates the energy of a photon to its (linear or angular) frequency,
 wavelength, and wavenumber. Whether to convert to linear or angular quantities is
@@ -44,63 +44,63 @@ Equivalent quantities are converted according to the relations
 # Examples
 
 ```jldoctest
-julia> uconvert(u"nm", 13.6u"eV", PhotonEnergy()) # photon wavelength needed to ionize hydrogen
+julia> uconvert(u"nm", 13.6u"eV", Spectral()) # photon wavelength needed to ionize hydrogen
 91.16485178911785 nm
 
-julia> uconvert(u"Hz", 589u"nm", PhotonEnergy(frequency=:angular)) # angular frequency of sodium D line
+julia> uconvert(u"Hz", 589u"nm", Spectral(frequency=:angular)) # angular frequency of sodium D line
 3.1980501991661345e15 Hz
 ```
 """
-struct PhotonEnergy{freq, len, num} <: Equivalence
-    function PhotonEnergy{freq, len, num}() where {freq, len, num}
-        check_photonarg(freq)
-        check_photonarg(len)
-        check_photonarg(num)
+struct Spectral{freq, len, num} <: Equivalence
+    function Spectral{freq, len, num}() where {freq, len, num}
+        check_photonarg(freq, :frequency)
+        check_photonarg(len, :wavelength)
+        check_photonarg(num, :wavenumber)
         new()
     end
 end
 
-@inline check_photonarg(s::Symbol) =
-    s === :linear || s === :angular || throw(ArgumentError("PhotonEnergy parameter must be :linear or :angular"))
+@inline check_photonarg(s::Symbol, arg::Symbol) =
+    s === :linear || s === :angular || throw(ArgumentError("`$arg` argument must be :linear or :angular"))
 
-PhotonEnergy(; frequency=:linear, wavelength=:linear, wavenumber=:linear) =
-    PhotonEnergy{frequency, wavelength, wavenumber}()
+Spectral(; frequency=:linear, wavelength=:linear, wavenumber=:linear) =
+    Spectral{frequency, wavelength, wavenumber}()
 
-Base.show(io::IO, e::PhotonEnergy{freq, len, num}) where {freq, len, num} =
-    print(io, PhotonEnergy, "(frequency=", repr(freq), ", wavelength=", repr(len), ", wavenumber=", repr(num), ")")
+Base.show(io::IO, e::Spectral{freq, len, num}) where {freq, len, num} =
+    print(io, Spectral, "(frequency=", repr(freq), ", wavelength=", repr(len), ", wavenumber=", repr(num), ")")
 
-@eqrelation PhotonEnergy{:linear}  Energy/Frequency = h
-@eqrelation PhotonEnergy{:angular} Energy/Frequency = ħ
+@eqrelation Spectral{:linear}  Energy/Frequency = h
+@eqrelation Spectral{:angular} Energy/Frequency = ħ
 
-@eqrelation PhotonEnergy{F,:linear}  where F Energy*Length = h*c0
-@eqrelation PhotonEnergy{F,:angular} where F Energy*Length = ħ*c0
+@eqrelation Spectral{F,:linear}  where F Energy*Length = h*c0
+@eqrelation Spectral{F,:angular} where F Energy*Length = ħ*c0
 
-@eqrelation PhotonEnergy{F,L,:linear}  where {F,L} Energy/Wavenumber = h*c0
-@eqrelation PhotonEnergy{F,L,:angular} where {F,L} Energy/Wavenumber = ħ*c0
+@eqrelation Spectral{F,L,:linear}  where {F,L} Energy/Wavenumber = h*c0
+@eqrelation Spectral{F,L,:angular} where {F,L} Energy/Wavenumber = ħ*c0
 
-function edconvert(::dimtype(Frequency), x::Length, ::PhotonEnergy{F,L}) where {F,L}
+function edconvert(::dimtype(Frequency), x::Length, ::Spectral{F,L}) where {F,L}
     F === L       ? c0/x      :
     F === :linear ? c0/(π*2x) : 2c0*(π/x)
 end
-function edconvert(::dimtype(Length), x::Frequency, ::PhotonEnergy{F,L}) where {F,L}
+function edconvert(::dimtype(Length), x::Frequency, ::Spectral{F,L}) where {F,L}
     F === L       ? c0/x      :
     F === :linear ? c0/(π*2x) : 2c0*(π/x)
 end
 
-function edconvert(::dimtype(Frequency), x::Wavenumber, ::PhotonEnergy{F,L,N}) where {F,L,N}
+function edconvert(::dimtype(Frequency), x::Wavenumber, ::Spectral{F,L,N}) where {F,L,N}
     F === N       ? c0*x       :
     F === :linear ? c0/2*(x/π) : 2c0*(π*x)
 end
-function edconvert(::dimtype(Wavenumber), x::Frequency, ::PhotonEnergy{F,L,N}) where {F,L,N}
+function edconvert(::dimtype(Wavenumber), x::Frequency, ::Spectral{F,L,N}) where {F,L,N}
     F === N       ? x/c0       :
     F === :linear ? 2*(π*x)/c0 : (x/π)/2c0
 end
 
-function edconvert(::dimtype(Length), x::Wavenumber, ::PhotonEnergy{F,L,N}) where {F,L,N}
+function edconvert(::dimtype(Length), x::Wavenumber, ::Spectral{F,L,N}) where {F,L,N}
     L === N       ? inv(x)  :
     L === :linear ? 2*(π/x) : inv(2*(π*x))
 end
-function edconvert(::dimtype(Wavenumber), x::Length, ::PhotonEnergy{F,L,N}) where {F,L,N}
+function edconvert(::dimtype(Wavenumber), x::Length, ::Spectral{F,L,N}) where {F,L,N}
     L === N       ? inv(x)  :
     L === :linear ? 2*(π/x) : inv(2*(π*x))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,72 +114,72 @@ end
     @test uconvert(u"kg", 938.272_088_16u"MeV", MassEnergy()) ≈ᵤ 1u"mp"
 end
 
-@testset "PhotonEnergy" begin
-    @test PhotonEnergy() === PhotonEnergy(frequency=:linear, wavelength=:linear, wavenumber=:linear)
-    @test PhotonEnergy(frequency=:angular) === PhotonEnergy(frequency=:angular, wavelength=:linear, wavenumber=:linear)
-    @test sprint(show, PhotonEnergy()) === "PhotonEnergy(frequency=:linear, wavelength=:linear, wavenumber=:linear)"
+@testset "Spectral" begin
+    @test Spectral() === Spectral(frequency=:linear, wavelength=:linear, wavenumber=:linear)
+    @test Spectral(frequency=:angular) === Spectral(frequency=:angular, wavelength=:linear, wavenumber=:linear)
+    @test sprint(show, Spectral()) === "Spectral(frequency=:linear, wavelength=:linear, wavenumber=:linear)"
 
     # Energy ↔ frequency
     for L = (:linear, :angular), N = (:linear, :angular)
-        @test uconvert(u"eV", 1u"MHz", PhotonEnergy(frequency=:linear, wavelength=L, wavenumber=N)) ≈ᵤ 4.135_667_697e-09u"eV" # E = h*f
-        @test uconvert(u"J", 1u"ns^-1", PhotonEnergy(frequency=:angular, wavelength=L, wavenumber=N)) ≈ᵤ 1.054_571_818e-25u"J" # E = ħ*ω
-        @test uconvert(u"Hz", 1u"eV", PhotonEnergy(frequency=:linear, wavelength=L, wavenumber=N)) ≈ᵤ 2.417_989_242e+14u"Hz" # f = E/h
-        @test uconvert(u"fs^-1", 1u"J", PhotonEnergy(frequency=:angular, wavelength=L, wavenumber=N)) ≈ᵤ 9.482_521_562e+18u"fs^-1" # ω = E/ħ
+        @test uconvert(u"eV", 1u"MHz", Spectral(frequency=:linear, wavelength=L, wavenumber=N)) ≈ᵤ 4.135_667_697e-09u"eV" # E = h*f
+        @test uconvert(u"J", 1u"ns^-1", Spectral(frequency=:angular, wavelength=L, wavenumber=N)) ≈ᵤ 1.054_571_818e-25u"J" # E = ħ*ω
+        @test uconvert(u"Hz", 1u"eV", Spectral(frequency=:linear, wavelength=L, wavenumber=N)) ≈ᵤ 2.417_989_242e+14u"Hz" # f = E/h
+        @test uconvert(u"fs^-1", 1u"J", Spectral(frequency=:angular, wavelength=L, wavenumber=N)) ≈ᵤ 9.482_521_562e+18u"fs^-1" # ω = E/ħ
     end
 
     # Energy ↔ wavelength
     for F = (:linear, :angular), N = (:linear, :angular)
-        @test uconvert(u"eV", 1u"nm", PhotonEnergy(frequency=F, wavelength=:linear, wavenumber=N)) ≈ᵤ 1239.841_984u"eV" # E = h*c/λ
-        @test uconvert(u"J", 1u"Å", PhotonEnergy(frequency=F, wavelength=:angular, wavenumber=N)) ≈ᵤ 3.161_526_773e-16u"J" # E = ħ*c/ƛ
-        @test uconvert(u"nm", 1u"keV", PhotonEnergy(frequency=F, wavelength=:linear, wavenumber=N)) ≈ᵤ 1.239_841_984u"nm" # λ = h*c/E
-        @test uconvert(u"μm", 1u"J", PhotonEnergy(frequency=F, wavelength=:angular, wavenumber=N)) ≈ᵤ 3.161_526_773e-20u"μm" # ƛ = ħ*c/E
+        @test uconvert(u"eV", 1u"nm", Spectral(frequency=F, wavelength=:linear, wavenumber=N)) ≈ᵤ 1239.841_984u"eV" # E = h*c/λ
+        @test uconvert(u"J", 1u"Å", Spectral(frequency=F, wavelength=:angular, wavenumber=N)) ≈ᵤ 3.161_526_773e-16u"J" # E = ħ*c/ƛ
+        @test uconvert(u"nm", 1u"keV", Spectral(frequency=F, wavelength=:linear, wavenumber=N)) ≈ᵤ 1.239_841_984u"nm" # λ = h*c/E
+        @test uconvert(u"μm", 1u"J", Spectral(frequency=F, wavelength=:angular, wavenumber=N)) ≈ᵤ 3.161_526_773e-20u"μm" # ƛ = ħ*c/E
     end
 
     # Energy ↔ wavenumber
     for F = (:linear, :angular), L = (:linear, :angular)
-        @test uconvert(u"eV", 1u"cm^-1", PhotonEnergy(frequency=F, wavelength=L, wavenumber=:linear)) ≈ᵤ 0.000_123_984_1984u"eV" # E = h*c*ν̃
-        @test uconvert(u"J", 1u"m^-1", PhotonEnergy(frequency=F, wavelength=L, wavenumber=:angular)) ≈ᵤ 3.161_526_773e-26u"J" # E = ħ*c*k
-        @test uconvert(u"cm^-1", 1u"J", PhotonEnergy(frequency=F, wavelength=L, wavenumber=:linear)) ≈ᵤ 5.034_116_568e+22u"cm^-1" # ν̃ = E/(h*c)
-        @test uconvert(u"m^-1", 1u"eV", PhotonEnergy(frequency=F, wavelength=L, wavenumber=:angular)) ≈ᵤ 5.067_730_716e+06u"m^-1" # k = E/(ħ*c)
+        @test uconvert(u"eV", 1u"cm^-1", Spectral(frequency=F, wavelength=L, wavenumber=:linear)) ≈ᵤ 0.000_123_984_1984u"eV" # E = h*c*ν̃
+        @test uconvert(u"J", 1u"m^-1", Spectral(frequency=F, wavelength=L, wavenumber=:angular)) ≈ᵤ 3.161_526_773e-26u"J" # E = ħ*c*k
+        @test uconvert(u"cm^-1", 1u"J", Spectral(frequency=F, wavelength=L, wavenumber=:linear)) ≈ᵤ 5.034_116_568e+22u"cm^-1" # ν̃ = E/(h*c)
+        @test uconvert(u"m^-1", 1u"eV", Spectral(frequency=F, wavelength=L, wavenumber=:angular)) ≈ᵤ 5.067_730_716e+06u"m^-1" # k = E/(ħ*c)
     end
 
     # Frequency ↔ wavelength
     for N = (:linear, :angular)
-        @test uconvert(u"MHz", 1u"nm", PhotonEnergy(frequency=:linear, wavelength=:linear, wavenumber=N)) ≈ᵤ 299_792_458_000u"MHz" # f = c/λ
-        @test uconvert(u"ns^-1", 1u"Å", PhotonEnergy(frequency=:linear, wavelength=:angular, wavenumber=N)) ≈ᵤ 4.771_345_159e+08u"ns^-1" # f = c/(2π*ƛ)
-        @test uconvert(u"fs^-1", 1u"nm", PhotonEnergy(frequency=:angular, wavelength=:linear, wavenumber=N)) ≈ᵤ 1883.651_567u"fs^-1" # ω = 2π*c/λ
-        @test uconvert(u"Hz", 1u"m", PhotonEnergy(frequency=:angular, wavelength=:angular, wavenumber=N)) ≈ᵤ 299_792_458u"Hz" # ω = c/ƛ
+        @test uconvert(u"MHz", 1u"nm", Spectral(frequency=:linear, wavelength=:linear, wavenumber=N)) ≈ᵤ 299_792_458_000u"MHz" # f = c/λ
+        @test uconvert(u"ns^-1", 1u"Å", Spectral(frequency=:linear, wavelength=:angular, wavenumber=N)) ≈ᵤ 4.771_345_159e+08u"ns^-1" # f = c/(2π*ƛ)
+        @test uconvert(u"fs^-1", 1u"nm", Spectral(frequency=:angular, wavelength=:linear, wavenumber=N)) ≈ᵤ 1883.651_567u"fs^-1" # ω = 2π*c/λ
+        @test uconvert(u"Hz", 1u"m", Spectral(frequency=:angular, wavelength=:angular, wavenumber=N)) ≈ᵤ 299_792_458u"Hz" # ω = c/ƛ
 
-        @test uconvert(u"nm", 1u"MHz", PhotonEnergy(frequency=:linear, wavelength=:linear, wavenumber=N)) ≈ᵤ 299_792_458_000u"nm" # λ = c/f
-        @test uconvert(u"Å", 1u"ns^-1", PhotonEnergy(frequency=:linear, wavelength=:angular, wavenumber=N)) ≈ᵤ 4.771_345_159e+08u"Å" # ƛ = c/(2π*f)
-        @test uconvert(u"nm", 1u"fs^-1", PhotonEnergy(frequency=:angular, wavelength=:linear, wavenumber=N)) ≈ᵤ 1883.651_567u"nm" # λ = 2π*c/ω
-        @test uconvert(u"m", 1u"Hz", PhotonEnergy(frequency=:angular, wavelength=:angular, wavenumber=N)) ≈ᵤ 299_792_458u"m" # ƛ = c/ω
+        @test uconvert(u"nm", 1u"MHz", Spectral(frequency=:linear, wavelength=:linear, wavenumber=N)) ≈ᵤ 299_792_458_000u"nm" # λ = c/f
+        @test uconvert(u"Å", 1u"ns^-1", Spectral(frequency=:linear, wavelength=:angular, wavenumber=N)) ≈ᵤ 4.771_345_159e+08u"Å" # ƛ = c/(2π*f)
+        @test uconvert(u"nm", 1u"fs^-1", Spectral(frequency=:angular, wavelength=:linear, wavenumber=N)) ≈ᵤ 1883.651_567u"nm" # λ = 2π*c/ω
+        @test uconvert(u"m", 1u"Hz", Spectral(frequency=:angular, wavelength=:angular, wavenumber=N)) ≈ᵤ 299_792_458u"m" # ƛ = c/ω
     end
 
     # Frequency ↔ wavenumber
     for L = (:linear, :angular)
-        @test uconvert(u"MHz", 1u"cm^-1", PhotonEnergy(frequency=:linear, wavelength=L, wavenumber=:linear)) ≈ᵤ 29_979.2458u"MHz" # f = c*ν̃
-        @test uconvert(u"ns^-1", 1u"m^-1", PhotonEnergy(frequency=:linear, wavelength=L, wavenumber=:angular)) ≈ᵤ 0.047_713_451_59u"ns^-1" # f = c*k/2π
-        @test uconvert(u"fs^-1", 1u"cm^-1", PhotonEnergy(frequency=:angular, wavelength=L, wavenumber=:linear)) ≈ᵤ 0.000_188_365_1567u"fs^-1" # ω = 2π*c*ν̃
-        @test uconvert(u"Hz", 1u"m^-1", PhotonEnergy(frequency=:angular, wavelength=L, wavenumber=:angular)) ≈ᵤ 299_792_458u"Hz" # ω = c*k
+        @test uconvert(u"MHz", 1u"cm^-1", Spectral(frequency=:linear, wavelength=L, wavenumber=:linear)) ≈ᵤ 29_979.2458u"MHz" # f = c*ν̃
+        @test uconvert(u"ns^-1", 1u"m^-1", Spectral(frequency=:linear, wavelength=L, wavenumber=:angular)) ≈ᵤ 0.047_713_451_59u"ns^-1" # f = c*k/2π
+        @test uconvert(u"fs^-1", 1u"cm^-1", Spectral(frequency=:angular, wavelength=L, wavenumber=:linear)) ≈ᵤ 0.000_188_365_1567u"fs^-1" # ω = 2π*c*ν̃
+        @test uconvert(u"Hz", 1u"m^-1", Spectral(frequency=:angular, wavelength=L, wavenumber=:angular)) ≈ᵤ 299_792_458u"Hz" # ω = c*k
 
-        @test uconvert(u"cm^-1", 1u"MHz", PhotonEnergy(frequency=:linear, wavelength=L, wavenumber=:linear)) ≈ᵤ 3.335_640_952e-05u"cm^-1" # ν̃ = f/c
-        @test uconvert(u"m^-1", 1u"ns^-1", PhotonEnergy(frequency=:linear, wavelength=L, wavenumber=:angular)) ≈ᵤ 20.958_450_22u"m^-1" # k = 2π*f/c
-        @test uconvert(u"cm^-1", 1u"fs^-1", PhotonEnergy(frequency=:angular, wavelength=L, wavenumber=:linear)) ≈ᵤ 5308.837_459u"cm^-1" # ν̃ = ω/(2π*c)
-        @test uconvert(u"m^-1", 1u"Hz", PhotonEnergy(frequency=:angular, wavelength=L, wavenumber=:angular)) ≈ᵤ 3.335_640_952e-09u"m^-1" # k = ω/c
+        @test uconvert(u"cm^-1", 1u"MHz", Spectral(frequency=:linear, wavelength=L, wavenumber=:linear)) ≈ᵤ 3.335_640_952e-05u"cm^-1" # ν̃ = f/c
+        @test uconvert(u"m^-1", 1u"ns^-1", Spectral(frequency=:linear, wavelength=L, wavenumber=:angular)) ≈ᵤ 20.958_450_22u"m^-1" # k = 2π*f/c
+        @test uconvert(u"cm^-1", 1u"fs^-1", Spectral(frequency=:angular, wavelength=L, wavenumber=:linear)) ≈ᵤ 5308.837_459u"cm^-1" # ν̃ = ω/(2π*c)
+        @test uconvert(u"m^-1", 1u"Hz", Spectral(frequency=:angular, wavelength=L, wavenumber=:angular)) ≈ᵤ 3.335_640_952e-09u"m^-1" # k = ω/c
     end
 
     # Wavelength ↔ wavenumber
     for F = (:linear, :angular)
-        @test uconvert(u"nm", 1u"cm^-1", PhotonEnergy(frequency=F, wavelength=:linear, wavenumber=:linear)) ≈ᵤ 10_000_000u"nm" # λ = 1/ν̃
-        @test uconvert(u"Å", 1u"m^-1", PhotonEnergy(frequency=F, wavelength=:linear, wavenumber=:angular)) ≈ᵤ 6.283_185_307e+10u"Å" # λ = 2π/k
-        @test uconvert(u"nm", 1u"cm^-1", PhotonEnergy(frequency=F, wavelength=:angular, wavenumber=:linear)) ≈ᵤ 1.591_549_431e+06u"nm" # ƛ = 1/(2π*ν̃)
-        @test uconvert(u"m", 1u"m^-1", PhotonEnergy(frequency=F, wavelength=:angular, wavenumber=:angular)) ≈ᵤ 1u"m" # ƛ = 1/k
+        @test uconvert(u"nm", 1u"cm^-1", Spectral(frequency=F, wavelength=:linear, wavenumber=:linear)) ≈ᵤ 10_000_000u"nm" # λ = 1/ν̃
+        @test uconvert(u"Å", 1u"m^-1", Spectral(frequency=F, wavelength=:linear, wavenumber=:angular)) ≈ᵤ 6.283_185_307e+10u"Å" # λ = 2π/k
+        @test uconvert(u"nm", 1u"cm^-1", Spectral(frequency=F, wavelength=:angular, wavenumber=:linear)) ≈ᵤ 1.591_549_431e+06u"nm" # ƛ = 1/(2π*ν̃)
+        @test uconvert(u"m", 1u"m^-1", Spectral(frequency=F, wavelength=:angular, wavenumber=:angular)) ≈ᵤ 1u"m" # ƛ = 1/k
 
-        @test uconvert(u"cm^-1", 1u"nm", PhotonEnergy(frequency=F, wavelength=:linear, wavenumber=:linear)) ≈ᵤ 10_000_000u"cm^-1" # ν̃ = 1/λ
-        @test uconvert(u"m^-1", 1u"Å", PhotonEnergy(frequency=F, wavelength=:linear, wavenumber=:angular)) ≈ᵤ 6.283_185_307e+10u"m^-1" # k = 2π/λ
-        @test uconvert(u"cm^-1", 1u"nm", PhotonEnergy(frequency=F, wavelength=:angular, wavenumber=:linear)) ≈ᵤ 1.591_549_431e+06u"cm^-1" # ν̃ = 1/(2π*ƛ)
-        @test uconvert(u"m^-1", 1u"m", PhotonEnergy(frequency=F, wavelength=:angular, wavenumber=:angular)) ≈ᵤ 1u"m^-1" # k = 1/ƛ
+        @test uconvert(u"cm^-1", 1u"nm", Spectral(frequency=F, wavelength=:linear, wavenumber=:linear)) ≈ᵤ 10_000_000u"cm^-1" # ν̃ = 1/λ
+        @test uconvert(u"m^-1", 1u"Å", Spectral(frequency=F, wavelength=:linear, wavenumber=:angular)) ≈ᵤ 6.283_185_307e+10u"m^-1" # k = 2π/λ
+        @test uconvert(u"cm^-1", 1u"nm", Spectral(frequency=F, wavelength=:angular, wavenumber=:linear)) ≈ᵤ 1.591_549_431e+06u"cm^-1" # ν̃ = 1/(2π*ƛ)
+        @test uconvert(u"m^-1", 1u"m", Spectral(frequency=F, wavelength=:angular, wavenumber=:angular)) ≈ᵤ 1u"m^-1" # k = 1/ƛ
     end
 end
 


### PR DESCRIPTION
Both [astropy.units](https://docs.astropy.org/en/stable/units/equivalencies.html) and [yt](https://yt-project.org/doc/analyzing/units/unit_equivalencies.html) call it `spectral`, so it might be less confusing if we call it `Spectral` as well.